### PR TITLE
added aptana files into readme folder renamed as example.*

### DIFF
--- a/Openethics/README NOTES/example.project
+++ b/Openethics/README NOTES/example.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Openethics</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+		<nature>org.python.pydev.django.djangoNature</nature>
+	</natures>
+</projectDescription>

--- a/Openethics/README NOTES/example.pydevproject
+++ b/Openethics/README NOTES/example.pydevproject
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?>
+
+<pydev_project>
+<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+<path>/Openethics</path>
+</pydev_pathproperty>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">python</pydev_property>
+<pydev_variables_property name="org.python.pydev.PROJECT_VARIABLE_SUBSTITUTION">
+<key>DJANGO_MANAGE_LOCATION</key>
+<value>Openethics/manage.py</value>
+<key>DJANGO_SETTINGS_MODULE</key>
+<value>Openethics.settings</value>
+</pydev_variables_property>
+</pydev_project>


### PR DESCRIPTION
we include example aptana project files in the README folder for reference incase someone is building a new copy of th eworkspace as the Aptana import doesn't seem to work properly. they files are renamed as example.\* to get them past the .gitignore file.
