### PR TITLE
Publish lifecycle events to a message queue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip install -r requirements.txt --use-mirrors
 
 script:
-  - python manage.py test root ethicsapplication checklist applicationform review --verbosity=2 
+  - python manage.py test root ethicsapplication checklist applicationform review publisher --verbosity=2 

--- a/ethicsapplication/models.py
+++ b/ethicsapplication/models.py
@@ -123,6 +123,7 @@ class EthicsApplication(models.Model):
             self._add_to_principle_investigator_role()
             self.__original_id = self.id
             
+            
             application_created.send(sender=self, application=self)
             
         if(self.__original_principle_investigator != self.principle_investigator and self.__original_id == self.id ):#if pi has changed but id hasn't

--- a/publisher/__init__.py
+++ b/publisher/__init__.py
@@ -1,0 +1,1 @@
+import signals

--- a/publisher/models.py
+++ b/publisher/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/publisher/signals.py
+++ b/publisher/signals.py
@@ -1,35 +1,66 @@
-'''
-Created on Nov 9, 2012
-
-@author: jasonmarshall
-'''
 from ethicsapplication.signals import application_created
 from review.signals import application_accepted_by_reviewer,\
     application_rejected_by_reviewer
 import pika
 import json
+from django.conf import settings
 
-
+def _send_message(host, exchange_info, message, routing=''):
+    '''
+        This function uses the pika library to send a message to an AMQP queue.
+        
+        @param host: The AMQP host
+        @param exchange_info: a tuple (exchange_name, exchange_type)
+        @param message: The message body
+        @param routing: (optional) the routing key to use. 
+    
+    '''
+    
+    connection = pika.BlockingConnection(pika.ConnectionParameters(
+        host=host))
+    channel = connection.channel()
+    
+    channel.exchange_declare(exchange=exchange_info[0],
+                             exchange_type=exchange_info[1])
+    
+    
+    channel.basic_publish(exchange=exchange_info[0],
+                          routing_key=routing,
+                          body=message)
+    
+    connection.close()
 def lifecycle_event_handler(sender, **kwargs):
     '''
         This handler will send a message to a message queue
         with information about the lifecycle event.
+        The mesage will only be sent if the settings.PUBLISH_LIFECYCLE 
+        flag is set to True.
     '''
     
-    connection = pika.BlockingConnection(pika.ConnectionParameters(
-        host='localhost'))
-    channel = connection.channel()
+    host = settings.AMQP_HOST
     
-    channel.exchange_declare(exchange='ethics_lifecycle_events',
-                             exchange_type='fanout')
+    exchange_info = ('openethics_events', 'fanout')
+    
+    signal = kwargs['signal']
+    
+    if signal == application_created:
+        event_type = 'created'
+    elif signal == application_accepted_by_reviewer:
+        event_type = 'accepted'
+    elif signal == application_rejected_by_reviewer:
+        event_type = 'rejected'
+    else:
+        raise AttributeError('An unkonwn signal triggered the receiver!')
     
     
-    channel.basic_publish(exchange='ethics_lifecycle_events',
-                          routing_key='',
-                          body='test message')
-    
-    connection.close()
+    message = json.dumps({'application': kwargs['application'].id, 'event_type':event_type})
         
+    if settings.PUBLISH_LIFECYCLE:   
+        _send_message(host, exchange_info, message)
+    
+      
+      
+#connect to the signals of interest.  
 application_created.connect(lifecycle_event_handler)
 application_accepted_by_reviewer.connect(lifecycle_event_handler)
 application_rejected_by_reviewer.connect(lifecycle_event_handler)

--- a/publisher/signals.py
+++ b/publisher/signals.py
@@ -1,0 +1,35 @@
+'''
+Created on Nov 9, 2012
+
+@author: jasonmarshall
+'''
+from ethicsapplication.signals import application_created
+from review.signals import application_accepted_by_reviewer,\
+    application_rejected_by_reviewer
+import pika
+import json
+
+
+def lifecycle_event_handler(sender, **kwargs):
+    '''
+        This handler will send a message to a message queue
+        with information about the lifecycle event.
+    '''
+    
+    connection = pika.BlockingConnection(pika.ConnectionParameters(
+        host='localhost'))
+    channel = connection.channel()
+    
+    channel.exchange_declare(exchange='ethics_lifecycle_events',
+                             exchange_type='fanout')
+    
+    
+    channel.basic_publish(exchange='ethics_lifecycle_events',
+                          routing_key='',
+                          body='test message')
+    
+    connection.close()
+        
+application_created.connect(lifecycle_event_handler)
+application_accepted_by_reviewer.connect(lifecycle_event_handler)
+application_rejected_by_reviewer.connect(lifecycle_event_handler)

--- a/publisher/tests/__init__.py
+++ b/publisher/tests/__init__.py
@@ -1,0 +1,1 @@
+from signals import *

--- a/publisher/tests/signals.py
+++ b/publisher/tests/signals.py
@@ -1,5 +1,13 @@
 from django.test import TestCase
-
+from mock import patch, call
+from ethicsapplication.signals import application_created
+from review.signals import application_accepted_by_reviewer,\
+    application_rejected_by_reviewer
+from ethicsapplication.models import EthicsApplication
+from django.contrib.auth.models import User
+from django.conf import settings
+import json
+from publisher.signals import lifecycle_event_handler
 
 class SignalsTests(TestCase):
     
@@ -13,19 +21,44 @@ class SignalsTests(TestCase):
     
             when any of these signals is raised then the lifecycle_event_handler should be called
         '''
+        signals_to_test = [application_created, application_accepted_by_reviewer, application_rejected_by_reviewer]
         
-        self.assertTrue(False)
+        #check that  our function is in the registered functions for each of the required signals
+        for signal in signals_to_test:
+            registered_functions = [r[1]() for r in signal.receivers]
+            self.assertTrue(lifecycle_event_handler in registered_functions)
         
     def test_event_handler(self):
         '''
-            When the event handler is called , it should connect to an AMQP server
-            using the connection details from the settings file (AMQP_SERVER).
-            
-            It should then connect to a fanout exchange called 'openethics_events'.
-            
-            Finally it should publish a message to this exchange, the contents of this message
-            should be a JSON string:
+            When the event handler is called , it should call the _send_message
+            function using the connection details from the settings file (AMQP_HOST),
+            specifying a fanout exchange called 'openethics_events' and a message which is a
+            JSON string like=:
             {'event_type':<application_created|application_accepted_by_reviewer|application_rejected_by_reviewer>,
                 'application':<application_id>}
+                
+            the event_type will depend on the signal that triggered the receiver.
         '''
-        self.assertTrue(False)
+        
+        
+        test_application = EthicsApplication.objects.create(title='test application', 
+                                                            principle_investigator=User.objects.create_user('username', 'email', 'password'))
+        test_params = [(application_created, 'created'), (application_accepted_by_reviewer, 'accepted'), (application_rejected_by_reviewer, 'rejected')]
+        
+        #now that we have created our test ethics application it is safe to turn on the Publish_lifecycle flag
+        settings.PUBLISH_LIFECYCLE = True
+        
+        with patch('publisher.signals._send_message') as send_message_mock:
+            for param in test_params:
+                lifecycle_event_handler(None, signal=param[0], application=test_application)
+                
+        self.assertEqual(send_message_mock.mock_calls, [
+            call('localhost', ('openethics_events', 'fanout'), '{"application": 1, "event_type": "created"}'),
+            call('localhost', ('openethics_events', 'fanout'), '{"application": 1, "event_type": "accepted"}'),
+            call('localhost', ('openethics_events', 'fanout'), '{"application": 1, "event_type": "rejected"}')
+                                                        ])
+        
+        settings.PUBLISH_LIFECYCLE = False
+        
+        
+            

--- a/publisher/tests/signals.py
+++ b/publisher/tests/signals.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+
+
+class SignalsTests(TestCase):
+    
+    def test_signal_bindings(self):
+        '''
+            This module should be connected to the following signal:
+            
+            application_created
+            application_accepted_by_reviewer
+            application_rejected_by_reviewer
+    
+            when any of these signals is raised then the lifecycle_event_handler should be called
+        '''
+        
+        self.assertTrue(False)
+        
+    def test_event_handler(self):
+        '''
+            When the event handler is called , it should connect to an AMQP server
+            using the connection details from the settings file (AMQP_SERVER).
+            
+            It should then connect to a fanout exchange called 'openethics_events'.
+            
+            Finally it should publish a message to this exchange, the contents of this message
+            should be a JSON string:
+            {'event_type':<application_created|application_accepted_by_reviewer|application_rejected_by_reviewer>,
+                'application':<application_id>}
+        '''
+        self.assertTrue(False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ nose==1.2.1
 pylint==0.25.2
 wsgiref==0.1.2
 mock-django==0.6.2
+pika==0.9.6
 
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python manage.py test root ethicsapplication checklist basicapplication --verbosity=2 --with-coverage --cover-package=root,ethicsapplication,checklist,basicapplication
+python manage.py test root ethicsapplication checklist basicapplication publisher--verbosity=2 --with-coverage --cover-package=root,ethicsapplication,checklist,basicapplication

--- a/settings.py
+++ b/settings.py
@@ -138,6 +138,7 @@ INSTALLED_APPS = (
     'checklist',
     'applicationform',
     'workflowutils',
+    'publisher',
     'django_nose',
     'django_jenkins',
     'review',

--- a/settings.py
+++ b/settings.py
@@ -160,6 +160,9 @@ LOGIN_REDIRECT_URL = '/'
 APPLICATION_WORKFLOW = 'Ethics_Application_Approval'
 PRINCIPLE_INVESTIGATOR_ROLE = 'Principle_Investigator'
 REVIEWER_ROLE = 'Reviewer'
+
+AMQP_HOST='localhost'
+PUBLISH_LIFECYCLE = False
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.


### PR DESCRIPTION
This connects to various application lifecycle signals and sends messages to a message queue to allow listeners to be informed of such events.
